### PR TITLE
Prevent failed commenting in PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,7 @@ jobs:
         run: npm run coverage
 
       - name: Comment Coverage on PR
+        if: ${{ ! github.event.pull_request.head.repo.fork }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PR-s from forks do not have the permission to comment.