### PR TITLE
Fix warning in PR commenting step

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,5 +33,5 @@ jobs:
         if: ${{ ! github.event.pull_request.head.repo.fork }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           path: ./coverage/report.txt


### PR DESCRIPTION
That parameter has a new name: https://github.com/marocchino/sticky-pull-request-comment/blob/44e0bad81007ecff41ba26d1cbf49a0267d28e9d/action.yml#L81